### PR TITLE
fix: failing confd if single service key is missing

### DIFF
--- a/datadog/confd/templates/elastic.yaml.tmpl
+++ b/datadog/confd/templates/elastic.yaml.tmpl
@@ -12,11 +12,11 @@ instances:
   # you will need to set `is_external` to true otherwise the check will compare
   # the local hostname against hostnames of the Elasticsearch nodes and only
   # submit metrics if they match.
-{{range gets "/skydns/local/example/staging/elasticsearch-9200/*"}}  
+{{$path:="/skydns/local/example/staging/elasticsearch-9200"}}{{if ls $path}}{{range gets (printf "%s/*" $path)}}
   {{$data := json .Value}}
 
   - url: http://{{ $data.host }}:{{ $data.port }}
     is_external: true
     tags:
      - 'environment:staging'
-{{end}}
+{{end}}{{end}}

--- a/datadog/confd/templates/etcd.yaml.tmpl
+++ b/datadog/confd/templates/etcd.yaml.tmpl
@@ -1,7 +1,7 @@
 init_config:
 
 instances:
-{{range gets "/operations/etcd/*"}}  
+{{$path:="/operations/etcd"}}{{if ls $path}}{{range gets (printf "%s/*" $path)}}
   {{$data := json .Value}}
 
 # url, the API endpoint of your etcd instance
@@ -9,4 +9,4 @@ instances:
 # timeout, time to wait on a etcd API request
      timeout: 5
 
-{{ end }}
+{{ end }}{{ end }}

--- a/datadog/confd/templates/http_check.yaml.tmpl
+++ b/datadog/confd/templates/http_check.yaml.tmpl
@@ -3,7 +3,7 @@ init_config:
   # ca_certs: /etc/ssl/certs/ca-certificates.crt
 
 instances:
-{{range gets "/skydns/local/example/staging/rabbitmq-15672/*"}}
+{{$path:="/skydns/local/example/staging/rabbitmq-15672"}}{{if ls $path}}{{range gets (printf "%s/*" $path)}}
   {{$data := json .Value}}
 
   - name: rabbitmq
@@ -77,9 +77,9 @@ instances:
       - url:http://rabbitmq-15672.staging.example.local
       - environment:staging
 
-{{end}}
+{{end}}{{end}}
 
-{{range gets "/skydns/local/example/staging/kibana/*"}}
+{{$path:="/skydns/local/example/staging/kibana"}}{{if ls $path}}{{range gets (printf "%s/*" $path)}}
   {{$data := json .Value}}
 
   - name: kibana
@@ -93,9 +93,9 @@ instances:
       - url:http://kibana.staging.example.local
       - environment:staging
 
-{{end}}
+{{end}}{{end}}
 
-{{range gets "/skydns/local/example/staging/elasticsearch-9200/*"}}
+{{$path:="/skydns/local/example/staging/elasticsearch-9200"}}{{if ls $path}}{{range gets (printf "%s/*" $path)}}
   {{$data := json .Value}}
 
   - name: elasticsearch-nodes
@@ -109,9 +109,9 @@ instances:
       - url:http://elasticsearch-9200.staging.example.local
       - environment:staging
 
-{{end}}
+{{end}}{{end}}
 
-{{range gets "/skydns/local/example/staging/elasticsearch_client/*"}}
+{{$path:="/skydns/local/example/staging/elasticsearch_client"}}{{if ls $path}}{{range gets (printf "%s/*" $path)}}
   {{$data := json .Value}}
 
   - name: elasticsearch-clients
@@ -125,4 +125,4 @@ instances:
       - url:http://elasticsearch_client.staging.example.local
       - environment:staging
 
-{{end}}
+{{end}}{{end}}

--- a/datadog/confd/templates/rabbitmq.yaml.tmpl
+++ b/datadog/confd/templates/rabbitmq.yaml.tmpl
@@ -23,7 +23,7 @@ instances:
   # using the aliveness API. If you prefer only certain vhosts to be monitored
   # then you can list the vhosts you care about.
   #
-{{range gets "/skydns/local/example/staging/rabbitmq-15672/*"}}
+{{$path:="/skydns/local/example/staging/rabbitmq-15672"}}{{if ls $path}}{{range gets (printf "%s/*" $path)}}
   {{$data := json .Value}}
 
   - rabbitmq_api_url: http://{{$data.host}}:{{$data.port}}/api/
@@ -43,4 +43,4 @@ instances:
     # vhosts:
     #   - vhost1
     #   - vhost2
-{{end}}
+{{end}}{{end}}


### PR DESCRIPTION
confd's 'gets' returns an error instead of an empty list if the given
path does not exist. Therefor if a single key does not exist, the whole
config becomes stale.

Fixes #1
